### PR TITLE
fix: In realm code, use txlink.URL

### DIFF
--- a/realm/post.gno
+++ b/realm/post.gno
@@ -8,6 +8,7 @@ import (
 
 	"gno.land/p/demo/avl"
 	"gno.land/p/demo/ufmt"
+	"gno.land/p/moul/txlink"
 )
 
 var debugNowOffset time.Duration
@@ -182,27 +183,25 @@ func (post *Post) GetURL() string {
 }
 
 func (post *Post) GetGnodFormURL() string {
-	return "/r/berty/social?help&__func=AddReaction" +
-		"&userPostsAddr=" + post.userPosts.userAddr.String() +
-		"&threadid=" + post.threadID.String() +
-		"&postid=" + post.id.String() +
-		"&reaction=" + strconv.Itoa(int(Gnod))
+	return txlink.URL("AddReaction",
+		"userPostsAddr", post.userPosts.userAddr.String(),
+		"threadid", post.threadID.String(),
+		"postid", post.id.String(),
+		"reaction", strconv.Itoa(int(Gnod)))
 }
 
 func (post *Post) GetReplyFormURL() string {
-	return "/r/berty/social?help&__func=PostReply" +
-		"&userPostsAddr=" + post.userPosts.userAddr.String() +
-		"&threadid=" + post.threadID.String() +
-		"&postid=" + post.id.String() +
-		"&comment.type=textarea"
+	return txlink.URL("PostReply",
+		"userPostsAddr", post.userPosts.userAddr.String(),
+		"threadid", post.threadID.String(),
+		"postid", post.id.String())
 }
 
 func (post *Post) GetRepostFormURL() string {
-	return "/r/berty/social?help&__func=RepostThread" +
-		"&userPostsAddr=" + post.userPosts.userAddr.String() +
-		"&threadid=" + post.threadID.String() +
-		"&postid=" + post.id.String() +
-		"&body.type=textarea"
+	return txlink.URL("RepostThread",
+		"userPostsAddr", post.userPosts.userAddr.String(),
+		"threadid", post.threadID.String(),
+		"postid", post.id.String())
 }
 
 func (post *Post) RenderSummary() string {

--- a/realm/userposts.gno
+++ b/realm/userposts.gno
@@ -10,6 +10,7 @@ import (
 
 	"gno.land/p/demo/avl"
 	"gno.land/p/demo/ufmt"
+	"gno.land/p/moul/txlink"
 	"gno.land/r/demo/users"
 )
 
@@ -208,23 +209,19 @@ func (userPosts *UserPosts) GetURLFromThreadAndReplyID(threadID, replyID PostID)
 }
 
 func (userPosts *UserPosts) GetPostFormURL() string {
-	return "/r/berty/social?help&__func=PostMessage" +
-		"&body.type=textarea"
+	return txlink.URL("PostMessage")
 }
 
 func (userPosts *UserPosts) GetFollowFormURL() string {
-	return "/r/berty/social?help&__func=Follow" +
-		"&followedAddr=" + userPosts.userAddr.String()
+	return txlink.URL("Follow", "followedAddr", userPosts.userAddr.String())
 }
 
 func (userPosts *UserPosts) GetUnfollowFormURL(followedAddr std.Address) string {
-	return "/r/berty/social?help&__func=Unfollow" +
-		"&followedAddr=" + followedAddr.String()
+	return txlink.URL("Unfollow", "followedAddr", followedAddr.String())
 }
 
 func (userPosts *UserPosts) GetRefreshFormURL() string {
-	return "/r/berty/social?help&__func=RefreshHomePosts" +
-		"&userPostsAddr=" + userPosts.userAddr.String()
+	return txlink.URL("RefreshHomePosts", "userPostsAddr", userPosts.userAddr.String())
 }
 
 // Scan userPosts.following for all posts from all followed users starting from lastRefreshId+1 .


### PR DESCRIPTION
PR https://github.com/gnolang/gno/pull/2887 introduced the helper function `txlink.URL` to format the URL "help" screen for the gnokey command. It also updated r/demo/boards to use it. In dSocial, we have a similar need. This PR updates the realm code to use `txlink.URL` . As an advantage, this is future proofing against changes to the "help" screen, as happened a few weeks ago in PR https://github.com/gnolang/gno/pull/2876 . Without using `txlink.URL`, those are breaking changes.