### PR TITLE
chore: make the google auth file optional with new EAS profile

### DIFF
--- a/mobile/app.config.js
+++ b/mobile/app.config.js
@@ -4,11 +4,11 @@ export default ({ config }) => {
       ...config,
       ios: {
         ...config.ios,
-        googleServicesFile: process.env.GOOGLESERVICES_INFO_PLIST || "./GoogleService-Info.plist",
+        googleServicesFile: process.env.GOOGLESERVICES_INFO_PLIST,
       },
       android: {
         ...config.android,
-        googleServicesFile: process.env.GOOGLE_SERVICES_JSON || "./google-services.json",
+        googleServicesFile: process.env.GOOGLE_SERVICES_JSON,
       },
     };
   } else {

--- a/mobile/eas.json
+++ b/mobile/eas.json
@@ -19,6 +19,13 @@
         "MY_ENVIRONMENT": "production"
       }
     },
+    "local-production": {
+      "env": {
+        "MY_ENVIRONMENT": "production",
+        "GOOGLESERVICES_INFO_PLIST": "./GoogleService-Info.plist",
+        "GOOGLE_SERVICES_JSON": "./google-services.json"
+      }
+    },
     "production": {
       "env": {
         "MY_ENVIRONMENT": "production"


### PR DESCRIPTION
In `app.config.js`, we want that `GoogleService-Info.plist` and `GoogleService-Info.plist` can be optional for the CI, and only use them locally by setting the `local-production` profile