### PR TITLE
fix: Change txlink.URL to txlink.Call

### DIFF
--- a/realm/post.gno
+++ b/realm/post.gno
@@ -183,7 +183,7 @@ func (post *Post) GetURL() string {
 }
 
 func (post *Post) GetGnodFormURL() string {
-	return txlink.URL("AddReaction",
+	return txlink.Call("AddReaction",
 		"userPostsAddr", post.userPosts.userAddr.String(),
 		"threadid", post.threadID.String(),
 		"postid", post.id.String(),
@@ -191,14 +191,14 @@ func (post *Post) GetGnodFormURL() string {
 }
 
 func (post *Post) GetReplyFormURL() string {
-	return txlink.URL("PostReply",
+	return txlink.Call("PostReply",
 		"userPostsAddr", post.userPosts.userAddr.String(),
 		"threadid", post.threadID.String(),
 		"postid", post.id.String())
 }
 
 func (post *Post) GetRepostFormURL() string {
-	return txlink.URL("RepostThread",
+	return txlink.Call("RepostThread",
 		"userPostsAddr", post.userPosts.userAddr.String(),
 		"threadid", post.threadID.String(),
 		"postid", post.id.String())

--- a/realm/userposts.gno
+++ b/realm/userposts.gno
@@ -209,19 +209,19 @@ func (userPosts *UserPosts) GetURLFromThreadAndReplyID(threadID, replyID PostID)
 }
 
 func (userPosts *UserPosts) GetPostFormURL() string {
-	return txlink.URL("PostMessage")
+	return txlink.Call("PostMessage")
 }
 
 func (userPosts *UserPosts) GetFollowFormURL() string {
-	return txlink.URL("Follow", "followedAddr", userPosts.userAddr.String())
+	return txlink.Call("Follow", "followedAddr", userPosts.userAddr.String())
 }
 
 func (userPosts *UserPosts) GetUnfollowFormURL(followedAddr std.Address) string {
-	return txlink.URL("Unfollow", "followedAddr", followedAddr.String())
+	return txlink.Call("Unfollow", "followedAddr", followedAddr.String())
 }
 
 func (userPosts *UserPosts) GetRefreshFormURL() string {
-	return txlink.URL("RefreshHomePosts", "userPostsAddr", userPosts.userAddr.String())
+	return txlink.Call("RefreshHomePosts", "userPostsAddr", userPosts.userAddr.String())
 }
 
 // Scan userPosts.following for all posts from all followed users starting from lastRefreshId+1 .


### PR DESCRIPTION
This is a follow-up to PR https://github.com/gnoverse/dsocial/pull/138 where we changed the realm code to use `txlink.URL`. Now, in the breaking change of PR https://github.com/gnolang/gno/pull/3289 this was renamed to `txlink.Call` . As show in the [changes to r/demo/boards,](https://github.com/gnolang/gno/pull/3289/files#diff-4b154b6eeb8243a0d18b7211540bcff8bc22d4fd0de567c9f77804b53423d8ed) all we have to do is rename.