### PR TITLE
fix: In gno.mod, remove require

### DIFF
--- a/realm/gno.mod
+++ b/realm/gno.mod
@@ -1,6 +1,1 @@
 module gno.land/r/berty/social
-
-require (
-	gno.land/p/demo/avl v0.0.0-latest
-	gno.land/r/demo/users v0.0.0-latest
-)


### PR DESCRIPTION
There is a breaking change (for the better) in PR https://github.com/gnolang/gno/pull/3123 which removes the useless `require` statement from `gno.mod` . That PR [updated `gno.mod`](https://github.com/gnolang/gno/pull/3123/files#diff-0b555c4db5d3502bf36327c922783d40fec73107b42c7cd69656b374e2a3f5dd) in many realms. This PR does the same to remove `require` from our `gno.mod`.