### PR TITLE
fix: In ListUsersByPrefix, pass the address of the tree to ListByteStringKeysByPrefix

### DIFF
--- a/realm/public.gno
+++ b/realm/public.gno
@@ -416,7 +416,7 @@ func GetJsonFollowing(address std.Address, startIndex int, endIndex int) string 
 // Get a list of user names starting from the given prefix. Limit the
 // number of results to maxResults.
 func ListUsersByPrefix(prefix string, maxResults int) []string {
-	return avlhelpers.ListByteStringKeysByPrefix(gUserAddressByName, prefix, maxResults)
+	return avlhelpers.ListByteStringKeysByPrefix(&gUserAddressByName, prefix, maxResults)
 }
 
 // Get a list of user names starting from the given prefix. Limit the


### PR DESCRIPTION
A [recent gno PR](https://github.com/gnolang/gno/pull/3377/files#diff-a294482bc80501435f316c1256e53b17f30307d652ca7327389197d14fe04569) has a breaking change to make `ListByteStringKeysByPrefix` use the new `avl.ITree` interface. As shown in that PR's [update to users.go](https://github.com/gnolang/gno/pull/3377/files#diff-06fa8b65268e852f436005d01a174bd6ca9915524438e1effffeccfe02e9a543), it's necessary to pass the address of the tree when calling `ListByteStringKeysByPrefix`. This PR does the same thing in dsocial.