### PR TITLE
Feat: use latest std + users realm

### DIFF
--- a/mobile/redux/features/accountSlice.ts
+++ b/mobile/redux/features/accountSlice.ts
@@ -35,7 +35,7 @@ export const loggedIn = createAsyncThunk<User, LoginParam, ThunkExtra>("account/
 async function getAccountName(bech32: string, gnonative: GnoNativeApi) {
   try {
     console.log("GetUserByAddress request:", bech32);
-    const accountNameStr = await gnonative.qEval("gno.land/r/demo/users", `GetUserByAddress("${bech32}").Name`);
+    const accountNameStr = await gnonative.qEval("gno.land/r/sys/users", `ResolveAddress("${bech32}").Name()`);
     console.log("GetUserByAddress result:", accountNameStr);
     const accountName = accountNameStr.match(/\("(\w+)"/)?.[1];
     console.log("GetUserByAddress after regex", accountName);

--- a/realm/public.gno
+++ b/realm/public.gno
@@ -20,7 +20,7 @@ type UserAndPostID struct {
 // Return the "thread ID" of the new post.
 // (This is similar to boards.CreateThread, but no message title)
 func PostMessage(body string) PostID {
-	caller := std.GetOrigCaller()
+	caller := std.OriginCaller()
 	name := usernameOf(caller)
 	if name == "" {
 		panic("please register")
@@ -38,7 +38,7 @@ func PostMessage(body string) PostID {
 // Return the new post ID.
 // (This is similar to boards.CreateReply.)
 func PostReply(userPostsAddr std.Address, threadid, postid PostID, body string) PostID {
-	caller := std.GetOrigCaller()
+	caller := std.OriginCaller()
 	if usernameOf(caller) == "" {
 		panic("please register")
 	}
@@ -68,7 +68,7 @@ func PostReply(userPostsAddr std.Address, threadid, postid PostID, body string) 
 // Return the new post ID.
 // (This is similar to boards.CreateRepost.)
 func RepostThread(userPostsAddr std.Address, threadid PostID, comment string) PostID {
-	caller := std.GetOrigCaller()
+	caller := std.OriginCaller()
 	if userPostsAddr == caller {
 		panic("Cannot repost a user's own message")
 	}
@@ -225,7 +225,7 @@ func GetJsonHomePosts(userPostsAddr std.Address, startIndex int, endIndex int) s
 
 // Update the caller to follow the user with followedAddr. See UserPosts.Follow.
 func Follow(followedAddr std.Address) PostID {
-	caller := std.GetOrigCaller()
+	caller := std.OriginCaller()
 	name := usernameOf(caller)
 	if name == "" {
 		panic("please register")
@@ -242,7 +242,7 @@ func Follow(followedAddr std.Address) PostID {
 
 // Update the caller to unfollow the user with followedAddr. See UserPosts.Unfollow.
 func Unfollow(followedAddr std.Address) {
-	caller := std.GetOrigCaller()
+	caller := std.OriginCaller()
 	name := usernameOf(caller)
 	if name == "" {
 		panic("please register")
@@ -264,7 +264,7 @@ func Unfollow(followedAddr std.Address) {
 // The caller must already be registered with /r/gnoland/users/v1 Register.
 // Return a boolean indicating whether the userAddr was added. See Post.AddReaction.
 func AddReaction(userPostsAddr std.Address, threadid, postid PostID, reaction Reaction) bool {
-	caller := std.GetOrigCaller()
+	caller := std.OriginCaller()
 	if usernameOf(caller) == "" {
 		panic("please register")
 	}
@@ -294,7 +294,7 @@ func AddReaction(userPostsAddr std.Address, threadid, postid PostID, reaction Re
 // The caller must already be registered with /r/gnoland/users/v1 Register.
 // Return a boolean indicating whether the userAddr was removed. See Post.RemoveReaction.
 func RemoveReaction(userPostsAddr std.Address, threadid, postid PostID, reaction Reaction) bool {
-	caller := std.GetOrigCaller()
+	caller := std.OriginCaller()
 	if usernameOf(caller) == "" {
 		panic("please register")
 	}
@@ -328,10 +328,10 @@ func GetJsonUserByAddress(addr std.Address) string {
 	return marshalJsonUser(user)
 }
 
-// Call users.GetUserByName and return the result as JSON, or "" if not found.
+// Call users.ResolveName and return the result as JSON, or "" if not found.
 // (This is a temporary utility until gno.land supports returning structured data directly.)
 func GetJsonUserByName(name string) string {
-	user := users.GetUserByName(name)
+	user, _ := users.ResolveName(name)
 	if user == nil {
 		return ""
 	}

--- a/realm/public.gno
+++ b/realm/public.gno
@@ -7,7 +7,7 @@ import (
 	"gno.land/p/demo/avl"
 	"gno.land/p/demo/avlhelpers"
 	"gno.land/p/demo/ufmt"
-	"gno.land/r/demo/users"
+	"gno.land/r/sys/users"
 )
 
 type UserAndPostID struct {
@@ -16,7 +16,7 @@ type UserAndPostID struct {
 }
 
 // Post a message to the caller's main user posts.
-// The caller must already be registered with /r/demo/users Register.
+// The caller must already be registered with /r/gnoland/users/v1 Register.
 // Return the "thread ID" of the new post.
 // (This is similar to boards.CreateThread, but no message title)
 func PostMessage(body string) PostID {
@@ -34,7 +34,7 @@ func PostMessage(body string) PostID {
 // Post a reply to the user posts of userPostsAddr where threadid is the ID returned by
 // the original call to PostMessage. If postid == threadid then create another top-level
 // post for the threadid, otherwise post a reply to the postid "sub reply".
-// The caller must already be registered with /r/demo/users Register.
+// The caller must already be registered with /r/gnoland/users/v1 Register.
 // Return the new post ID.
 // (This is similar to boards.CreateReply.)
 func PostReply(userPostsAddr std.Address, threadid, postid PostID, body string) PostID {
@@ -261,7 +261,7 @@ func Unfollow(followedAddr std.Address) {
 // returned by the original call to PostMessage. If postid == threadid then add the reaction
 // to a top-level post for the threadid, otherwise add the reaction to the postid "sub reply".
 // (This function's arguments are similar to PostReply.)
-// The caller must already be registered with /r/demo/users Register.
+// The caller must already be registered with /r/gnoland/users/v1 Register.
 // Return a boolean indicating whether the userAddr was added. See Post.AddReaction.
 func AddReaction(userPostsAddr std.Address, threadid, postid PostID, reaction Reaction) bool {
 	caller := std.GetOrigCaller()
@@ -291,7 +291,7 @@ func AddReaction(userPostsAddr std.Address, threadid, postid PostID, reaction Re
 // returned by the original call to PostMessage. If postid == threadid then remove the reaction
 // from a top-level post for the threadid, otherwise remove the reaction from the postid "sub reply".
 // (This function's arguments are similar to PostReply.)
-// The caller must already be registered with /r/demo/users Register.
+// The caller must already be registered with /r/gnoland/users/v1 Register.
 // Return a boolean indicating whether the userAddr was removed. See Post.RemoveReaction.
 func RemoveReaction(userPostsAddr std.Address, threadid, postid PostID, reaction Reaction) bool {
 	caller := std.GetOrigCaller()
@@ -317,10 +317,10 @@ func RemoveReaction(userPostsAddr std.Address, threadid, postid PostID, reaction
 	}
 }
 
-// Call users.GetUserByAddress and return the result as JSON, or "" if not found.
+// Call users.ResolveAddress and return the result as JSON, or "" if not found.
 // (This is a temporary utility until gno.land supports returning structured data directly.)
 func GetJsonUserByAddress(addr std.Address) string {
-	user := users.GetUserByAddress(addr)
+	user := users.ResolveAddress(addr)
 	if user == nil {
 		return ""
 	}

--- a/realm/render.gno
+++ b/realm/render.gno
@@ -4,7 +4,7 @@ import (
 	"strconv"
 	"strings"
 
-	"gno.land/r/demo/users"
+	"gno.land/r/sys/users"
 )
 
 func Render(path string) string {

--- a/realm/render.gno
+++ b/realm/render.gno
@@ -23,12 +23,12 @@ func Render(path string) string {
 	parts := strings.Split(path, "/")
 	if len(parts) == 1 {
 		// /r/berty/social:USER_NAME
-		user := users.GetUserByName(path)
+		user, _ := users.ResolveName(path)
 		if user == nil {
 			return "Unknown user: " + path
 		}
 
-		userPosts := getUserPosts(user.Address)
+		userPosts := getUserPosts(user.Addr())
 		if userPosts == nil {
 			return "No posts by: " + path
 		}
@@ -36,11 +36,11 @@ func Render(path string) string {
 		return userPosts.RenderUserPosts(false)
 	} else if len(parts) == 2 {
 		name := parts[0]
-		user := users.GetUserByName(name)
+		user, _ := users.ResolveName(name)
 		if user == nil {
 			return "Unknown user: " + name
 		}
-		userPosts := getUserPosts(user.Address)
+		userPosts := getUserPosts(user.Addr())
 		if userPosts == nil {
 			return "No posts by: " + name
 		}
@@ -69,11 +69,11 @@ func Render(path string) string {
 	} else if len(parts) == 3 {
 		// /r/berty/social:USER_NAME/THREAD_ID/REPLY_ID
 		name := parts[0]
-		user := users.GetUserByName(name)
+		user, _ := users.ResolveName(name)
 		if user == nil {
 			return "Unknown user: " + name
 		}
-		userPosts := getUserPosts(user.Address)
+		userPosts := getUserPosts(user.Addr())
 		if userPosts == nil {
 			return "No posts by: " + name
 		}

--- a/realm/userposts.gno
+++ b/realm/userposts.gno
@@ -11,7 +11,7 @@ import (
 	"gno.land/p/demo/avl"
 	"gno.land/p/demo/ufmt"
 	"gno.land/p/moul/txlink"
-	"gno.land/r/demo/users"
+	"gno.land/r/sys/users"
 )
 
 type FollowingInfo struct {
@@ -113,7 +113,7 @@ func (userPosts *UserPosts) RenderUserPosts(includeFollowed bool) string {
 	str := ""
 	followers := strconv.Itoa(userPosts.followers.Size()) + " Followers"
 	following := "Following " + strconv.Itoa(userPosts.following.Size())
-	user := users.GetUserByAddress(userPosts.userAddr)
+	user := users.ResolveAddress(userPosts.userAddr)
 	if user != nil {
 		followers = "[" + followers + "](/r/berty/social:" + user.Name + "/followers)"
 		following = "[" + following + "](/r/berty/social:" + user.Name + "/following)"
@@ -143,7 +143,7 @@ func (userPosts *UserPosts) RenderUserPosts(includeFollowed bool) string {
 
 func (userPosts *UserPosts) RenderFollowers() string {
 	str := ""
-	user := users.GetUserByAddress(userPosts.userAddr)
+	user := users.ResolveAddress(userPosts.userAddr)
 	if user != nil {
 		str += "[@" + user.Name + "](/r/berty/social:" + user.Name + ") "
 	}
@@ -152,7 +152,7 @@ func (userPosts *UserPosts) RenderFollowers() string {
 	// List the followers, sorted by name.
 	names := []string{}
 	userPosts.followers.Iterate("", "", func(key string, value interface{}) bool {
-		if user := users.GetUserByAddress(std.Address(key)); user != nil {
+		if user := users.ResolveAddress(std.Address(key)); user != nil {
 			names = append(names, user.Name)
 		}
 		return false
@@ -167,7 +167,7 @@ func (userPosts *UserPosts) RenderFollowers() string {
 
 func (userPosts *UserPosts) RenderFollowing() string {
 	str := ""
-	user := users.GetUserByAddress(userPosts.userAddr)
+	user := users.ResolveAddress(userPosts.userAddr)
 	if user != nil {
 		str += "[@" + user.Name + "](/r/berty/social:" + user.Name + ") "
 	}
@@ -177,7 +177,7 @@ func (userPosts *UserPosts) RenderFollowing() string {
 	nameAddrs := []string{}
 	userPosts.following.Iterate("", "", func(addr string, infoI interface{}) bool {
 		info := infoI.(*FollowingInfo)
-		if user := users.GetUserByAddress(std.Address(addr)); user != nil {
+		if user := users.ResolveAddress(std.Address(addr)); user != nil {
 			nameAddrs = append(nameAddrs, user.Name+"/"+addr+"/"+info.startedFollowingAt.Format("2006-01-02"))
 		}
 		return false

--- a/realm/userposts.gno
+++ b/realm/userposts.gno
@@ -115,8 +115,8 @@ func (userPosts *UserPosts) RenderUserPosts(includeFollowed bool) string {
 	following := "Following " + strconv.Itoa(userPosts.following.Size())
 	user := users.ResolveAddress(userPosts.userAddr)
 	if user != nil {
-		followers = "[" + followers + "](/r/berty/social:" + user.Name + "/followers)"
-		following = "[" + following + "](/r/berty/social:" + user.Name + "/following)"
+		followers = "[" + followers + "](/r/berty/social:" + user.Name() + "/followers)"
+		following = "[" + following + "](/r/berty/social:" + user.Name() + "/following)"
 	}
 	str += followers + " &nbsp;" + following + "\n\n"
 
@@ -145,7 +145,7 @@ func (userPosts *UserPosts) RenderFollowers() string {
 	str := ""
 	user := users.ResolveAddress(userPosts.userAddr)
 	if user != nil {
-		str += "[@" + user.Name + "](/r/berty/social:" + user.Name + ") "
+		str += "[@" + user.Name() + "](/r/berty/social:" + user.Name() + ") "
 	}
 	str += "Followers\n\n"
 
@@ -153,7 +153,7 @@ func (userPosts *UserPosts) RenderFollowers() string {
 	names := []string{}
 	userPosts.followers.Iterate("", "", func(key string, value interface{}) bool {
 		if user := users.ResolveAddress(std.Address(key)); user != nil {
-			names = append(names, user.Name)
+			names = append(names, user.Name())
 		}
 		return false
 	})
@@ -169,7 +169,7 @@ func (userPosts *UserPosts) RenderFollowing() string {
 	str := ""
 	user := users.ResolveAddress(userPosts.userAddr)
 	if user != nil {
-		str += "[@" + user.Name + "](/r/berty/social:" + user.Name + ") "
+		str += "[@" + user.Name() + "](/r/berty/social:" + user.Name() + ") "
 	}
 	str += "Following\n\n"
 
@@ -178,7 +178,7 @@ func (userPosts *UserPosts) RenderFollowing() string {
 	userPosts.following.Iterate("", "", func(addr string, infoI interface{}) bool {
 		info := infoI.(*FollowingInfo)
 		if user := users.ResolveAddress(std.Address(addr)); user != nil {
-			nameAddrs = append(nameAddrs, user.Name+"/"+addr+"/"+info.startedFollowingAt.Format("2006-01-02"))
+			nameAddrs = append(nameAddrs, user.Name()+"/"+addr+"/"+info.startedFollowingAt.Format("2006-01-02"))
 		}
 		return false
 	})

--- a/realm/util.gno
+++ b/realm/util.gno
@@ -108,7 +108,7 @@ func displayAddressMD(addr std.Address) string {
 	if user == nil {
 		return "[" + addr.String() + "](/r/gnoland/users/v1:" + addr.String() + ")"
 	} else {
-		return "[@" + user.Name + "](/r/berty/social:" + user.Name + ")"
+		return "[@" + user.Name() + "](/r/berty/social:" + user.Name() + ")"
 	}
 }
 
@@ -117,7 +117,7 @@ func usernameOf(addr std.Address) string {
 	if user == nil {
 		return ""
 	} else {
-		return user.Name
+		return user.Name()
 	}
 }
 

--- a/realm/util.gno
+++ b/realm/util.gno
@@ -7,8 +7,7 @@ import (
 
 	"gno.land/p/demo/avl"
 	"gno.land/p/demo/ufmt"
-	p_users "gno.land/p/demo/users"
-	"gno.land/r/demo/users"
+	"gno.land/r/sys/users"
 )
 
 //----------------------------------------
@@ -105,16 +104,16 @@ func summaryOf(str string, length int) string {
 }
 
 func displayAddressMD(addr std.Address) string {
-	user := users.GetUserByAddress(addr)
+	user := users.ResolveAddress(addr)
 	if user == nil {
-		return "[" + addr.String() + "](/r/demo/users:" + addr.String() + ")"
+		return "[" + addr.String() + "](/r/gnoland/users/v1:" + addr.String() + ")"
 	} else {
 		return "[@" + user.Name + "](/r/berty/social:" + user.Name + ")"
 	}
 }
 
 func usernameOf(addr std.Address) string {
-	user := users.GetUserByAddress(addr)
+	user := users.ResolveAddress(addr)
 	if user == nil {
 		return ""
 	} else {
@@ -124,8 +123,8 @@ func usernameOf(addr std.Address) string {
 
 // Return the User info as a JSON string.
 // (This is a temporary utility until gno.land supports returning structured data directly.)
-func marshalJsonUser(user *p_users.User) string {
+func marshalJsonUser(user *users.UserData) string {
 	return ufmt.Sprintf(
-		"{\"address\": \"%s\", \"name\": \"%s\", \"profile\": %s, \"number\": %d, \"invites\": %d, \"inviter\": \"%s\"}",
-		user.Address.String(), user.Name, strconv.Quote(user.Profile), user.Number, user.Invites, user.Inviter.String())
+		"{\"address\": \"%s\", \"name\": \"%s\", \"deleted\": %t}",
+		user.Addr().String(), user.Name(), user.IsDeleted())
 }


### PR DESCRIPTION
This PR update dsocial with the latest gno version.

So the dsocial realm:
- uses latest std functions (OriginCaller() instead of GetOriginCaller)
- uses the new `users` realm.

The mobile version is also updated to use the new `users` realm API.