### PR TITLE
feat: tell gnokey mobile to update GasWanted field

### DIFF
--- a/mobile/redux/features/linkingSlice.ts
+++ b/mobile/redux/features/linkingSlice.ts
@@ -69,6 +69,7 @@ export const makeCallTx = async (props: MakeCallTxParams, gnonative: GnoNativeAp
     url.searchParams.append('chain_id', await gnonative.getChainID());
     url.searchParams.append('remote', await gnonative.getRemote());
     url.searchParams.append('tx', res.txJson);
+    url.searchParams.append("update_tx", "true");
     url.searchParams.append('address', callerAddressBech32);
     url.searchParams.append('client_name', 'dSocial');
     url.searchParams.append('reason', reason);


### PR DESCRIPTION
The latest Gnokey Mobile version (https://github.com/gnolang/gnokey-mobile/pull/42) estimates the gas used for a transaction and can update the transaction with the GasWanted recommended value in the `update_tx` parameter is set in the deeplink.
So this PR adds this parameter.