### PR TITLE
fix: configure semantic-release-expo in the prepare flow

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -6,5 +6,14 @@
     "@semantic-release/release-notes-generator",
     "@semantic-release/npm",
     "@semantic-release/github"
-  ]
+  ],
+  "prepare": [
+        {
+            "path": "semantic-release-expo",
+            "manifests": [
+                "./mobile/app.json",
+            ]
+        }
+    ]
+  }
 }


### PR DESCRIPTION
Set manually the location of app.json because it is in a subfolder.