### PR TITLE
fix: semantic release expo android version

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -4,6 +4,7 @@
     "slug": "dsocial",
     "platforms": ["ios", "android"],
     "version": "1.0.0",
+    "sdkVersion": "52.0.0",
     "orientation": "portrait",
     "scheme": "tech.berty.dsocial",
     "icon": "./assets/images/icon.png",


### PR DESCRIPTION
Android Build doesn't have a dev version, due to this bug: https://github.com/byCedric/semantic-release-expo/issues/190#issuecomment-659040716

So trying to fix it by adding the `sdkVersion` in app.json.