### PR TITLE
fix: Upgrade to gnonative 4.7.1

### DIFF
--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -13,7 +13,7 @@
         "@bufbuild/protobuf": "^2.6.2",
         "@connectrpc/connect": "^2.0.3",
         "@connectrpc/connect-web": "^2.0.3",
-        "@gnolang/gnonative": "^4.7.0",
+        "@gnolang/gnonative": "^4.7.1",
         "@reduxjs/toolkit": "^2.1.0",
         "base-64": "^1.0.0",
         "date-fns": "^3.6.0",
@@ -2776,9 +2776,9 @@
       }
     },
     "node_modules/@gnolang/gnonative": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@gnolang/gnonative/-/gnonative-4.7.0.tgz",
-      "integrity": "sha512-fSgxezo/yIakv80fEZL0CiKMlNM1qy+5SST2a94E8BzeoJt2Mo2iuit34I5piUrLF9aAdl9u2XR3eE1LOSLSzg==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@gnolang/gnonative/-/gnonative-4.7.1.tgz",
+      "integrity": "sha512-Dc52U/GFBk2AafUWjY2R+mSKo+5Metqb6ZoFrINDGTkOyADKvFYT00A8IgB5HMwqsLZBiRdP3u2FZFL/WeNmRQ==",
       "dependencies": {
         "@bufbuild/protobuf": "^2.6.2",
         "@connectrpc/connect": "^2.0.3",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -16,7 +16,7 @@
     "@bufbuild/protobuf": "^2.6.2",
     "@connectrpc/connect": "^2.0.3",
     "@connectrpc/connect-web": "^2.0.3",
-    "@gnolang/gnonative": "^4.7.0",
+    "@gnolang/gnonative": "^4.7.1",
     "@reduxjs/toolkit": "^2.1.0",
     "base-64": "^1.0.0",
     "date-fns": "^3.6.0",

--- a/realm/post.gno
+++ b/realm/post.gno
@@ -6,9 +6,9 @@ import (
 	"strconv"
 	"time"
 
-	"gno.land/p/demo/avl"
-	"gno.land/p/demo/ufmt"
 	"gno.land/p/moul/txlink"
+	"gno.land/p/nt/avl"
+	"gno.land/p/nt/ufmt"
 )
 
 //----------------------------------------

--- a/realm/public.gno
+++ b/realm/public.gno
@@ -4,9 +4,9 @@ import (
 	"std"
 	"strconv"
 
-	"gno.land/p/demo/avl"
-	"gno.land/p/demo/avlhelpers"
-	"gno.land/p/demo/ufmt"
+	"gno.land/p/jefft0/avlhelpers"
+	"gno.land/p/nt/avl"
+	"gno.land/p/nt/ufmt"
 	"gno.land/r/sys/users"
 )
 

--- a/realm/social.gno
+++ b/realm/social.gno
@@ -1,7 +1,7 @@
 package social
 
 import (
-	"gno.land/p/demo/avl"
+	"gno.land/p/nt/avl"
 )
 
 var (

--- a/realm/userposts.gno
+++ b/realm/userposts.gno
@@ -8,9 +8,9 @@ import (
 	"strings"
 	"time"
 
-	"gno.land/p/demo/avl"
-	"gno.land/p/demo/ufmt"
 	"gno.land/p/moul/txlink"
+	"gno.land/p/nt/avl"
+	"gno.land/p/nt/ufmt"
 	"gno.land/r/sys/users"
 )
 

--- a/realm/util.gno
+++ b/realm/util.gno
@@ -5,8 +5,8 @@ import (
 	"strconv"
 	"strings"
 
-	"gno.land/p/demo/avl"
-	"gno.land/p/demo/ufmt"
+	"gno.land/p/nt/avl"
+	"gno.land/p/nt/ufmt"
 	"gno.land/r/sys/users"
 )
 


### PR DESCRIPTION
gnonative 4.7.1 is released which uses the latest gno packet formats
* Update to gnolang/gnonative 4.7.1
* In the realm gno code, update the imports to the new locations for helper packages like avl and ufmt

Of course, this release works with the update gnokey-mobile which also uses gnonative 4.7.1