### PR TITLE
fix: Use gnonative 4.7.2

### DIFF
--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -13,7 +13,7 @@
         "@bufbuild/protobuf": "^2.6.2",
         "@connectrpc/connect": "^2.0.3",
         "@connectrpc/connect-web": "^2.0.3",
-        "@gnolang/gnonative": "^4.7.1",
+        "@gnolang/gnonative": "^4.7.2",
         "@reduxjs/toolkit": "^2.1.0",
         "base-64": "^1.0.0",
         "date-fns": "^3.6.0",
@@ -2776,9 +2776,9 @@
       }
     },
     "node_modules/@gnolang/gnonative": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/@gnolang/gnonative/-/gnonative-4.7.1.tgz",
-      "integrity": "sha512-Dc52U/GFBk2AafUWjY2R+mSKo+5Metqb6ZoFrINDGTkOyADKvFYT00A8IgB5HMwqsLZBiRdP3u2FZFL/WeNmRQ==",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/@gnolang/gnonative/-/gnonative-4.7.2.tgz",
+      "integrity": "sha512-hiDMy1SoufEOCpuwzYceqDQ1Avl95XVUlcs/ZOd1IvXJ0o5fI8une4cg7+mCSyblI7DItryWdtgI/gg0dqQx9A==",
       "dependencies": {
         "@bufbuild/protobuf": "^2.6.2",
         "@connectrpc/connect": "^2.0.3",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -16,7 +16,7 @@
     "@bufbuild/protobuf": "^2.6.2",
     "@connectrpc/connect": "^2.0.3",
     "@connectrpc/connect-web": "^2.0.3",
-    "@gnolang/gnonative": "^4.7.1",
+    "@gnolang/gnonative": "^4.7.2",
     "@reduxjs/toolkit": "^2.1.0",
     "base-64": "^1.0.0",
     "date-fns": "^3.6.0",


### PR DESCRIPTION
As explained in https://github.com/gnolang/gnonative/pull/215, we updated Gno Native Kit to fix some breaking changes. This made new [gnonative NPM package version 4.7.2](https://www.npmjs.com/package/@gnolang/gnonative/v/4.7.2). Therefore, we update dSocial to use it.